### PR TITLE
Integrate Expo app with remote backend API

### DIFF
--- a/primeiro-app/App.js
+++ b/primeiro-app/App.js
@@ -13,7 +13,7 @@ import Page6 from './Page6'; // <<< NOVO
 import AnimatedBackground from './AnimatedBackground';
 import { typography } from './styles/typography';
 
-import { fetchAllPokemons } from './services/pokeapi';
+import { listPokemons } from './services/backend';
 
 const lightTheme = { bg: 'transparent', card: 'rgba(255, 255, 255, 0.85)', primary: '#EF4444', text: '#111827', subtle: '#9CA3AF' };
 const darkTheme = { bg: 'transparent', card: 'rgba(31, 41, 55, 0.85)', primary: '#FBBF24', text: '#F9FAFB', subtle: '#778DA9' };
@@ -55,11 +55,11 @@ export default function App() {
   useEffect(() => {
     (async () => {
       try {
-        const data = await fetchAllPokemons(1000);
+        const data = await listPokemons();
         setPokemons(data);
         setFilteredPokemons(data);
       } catch (e) {
-        console.log('Falha ao buscar Pokémon da PokeAPI:', e?.message);
+        console.log('Falha ao buscar Pokémon:', e?.message);
         setError('Falha ao carregar Pokémon.');
       } finally {
         setLoading(false);

--- a/primeiro-app/apiUrl.js
+++ b/primeiro-app/apiUrl.js
@@ -1,6 +1,6 @@
 // primeiro-app/apiUrl.js
 
 export function getApiBaseUrl() {
-  return 'https://seu-backend.onrender.com';
+  return 'https://pequedex.onrender.com';
 }
 

--- a/primeiro-app/services/backend.js
+++ b/primeiro-app/services/backend.js
@@ -1,0 +1,44 @@
+import { getApiBaseUrl } from '../apiUrl';
+
+const BASE = getApiBaseUrl();
+
+async function listPokemons() {
+  const res = await fetch(`${BASE}/api/pokemons`);
+  if (!res.ok) throw new Error(`Erro ${res.status}`);
+  return res.json();
+}
+
+async function getPokemon(id) {
+  const res = await fetch(`${BASE}/api/pokemons/${id}`);
+  if (!res.ok) throw new Error(`Erro ${res.status}`);
+  return res.json();
+}
+
+async function createPokemon(data) {
+  const res = await fetch(`${BASE}/api/pokemons`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) throw new Error(`Erro ${res.status}`);
+  return res.json();
+}
+
+async function updatePokemon(id, data) {
+  const res = await fetch(`${BASE}/api/pokemons/${id}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!res.ok) throw new Error(`Erro ${res.status}`);
+  return res.json();
+}
+
+async function deletePokemon(id) {
+  const res = await fetch(`${BASE}/api/pokemons/${id}`, { method: 'DELETE' });
+  if (!res.ok) throw new Error(`Erro ${res.status}`);
+  return res.json();
+}
+
+export { listPokemons, getPokemon, createPokemon, updatePokemon, deletePokemon };
+


### PR DESCRIPTION
## Summary
- point Expo frontend at Render deployment
- add backend service module for CRUD requests
- fetch and manage Pokémon through backend, including sprite URLs

## Testing
- `npm test` *(fails: Missing script "test")*

------
