### PR TITLE
Add local image uploads and sprite fallbacks

### DIFF
--- a/pokemon-backend/server.js
+++ b/pokemon-backend/server.js
@@ -7,7 +7,8 @@ const fs = require('fs');
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+// Aumenta limite para aceitar Data URIs base64 (~20 MB)
+app.use(express.json({ limit: '20mb' }));
 
 // ===== SSL (Aiven exige TLS) =====
 let caPem;

--- a/primeiro-app/package-lock.json
+++ b/primeiro-app/package-lock.json
@@ -16,6 +16,7 @@
         "expo": "~53.0.20",
         "expo-blur": "~14.1.5",
         "expo-constants": "~17.1.7",
+        "expo-image-picker": "^16.1.4",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-dom": "19.0.0",
@@ -4345,6 +4346,27 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.1.0.tgz",
+      "integrity": "sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.1.4",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.1.4.tgz",
+      "integrity": "sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.1.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-keep-awake": {

--- a/primeiro-app/package.json
+++ b/primeiro-app/package.json
@@ -16,6 +16,8 @@
     "axios": "^1.11.0",
     "expo": "~53.0.20",
     "expo-blur": "~14.1.5",
+    "expo-constants": "~17.1.7",
+    "expo-image-picker": "^16.1.4",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-dom": "19.0.0",
@@ -24,8 +26,7 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-vector-icons": "^10.3.0",
-    "react-native-web": "^0.20.0",
-    "expo-constants": "~17.1.7"
+    "react-native-web": "^0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
## Summary
- allow CRUD screen to pick images from device with preview and validation
- display sprites with officialArtwork/frontDefault/animated fallbacks
- increase backend JSON limit for base64 payloads

## Testing
- `npm test` (backend) *(fails: Error: no test specified)*
- `npm test` (frontend) *(fails: Missing script "test")*


------
